### PR TITLE
Change Node from 12 to 16

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -20,7 +20,7 @@ outputs:
   browser_download_url:
     description: 'The URL users can navigate to in order to download the uploaded asset'
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'dist/index.js'
 branding:
   icon: 'package'


### PR DESCRIPTION
Node 12 has been out of support since [April 2022.](https://github.com/nodejs/Release/#end-of-life-releases)